### PR TITLE
Set the default version as the last version

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,7 +2,7 @@
 <extension>
 	<dependency name="google-play-services" path="google-play-services" />
 	
-	<set name="playServicesVersion" value="9.4.0" unless="playServicesVersion" />
-	<set name="supportLibraryVersion" value="23.2.0" unless="supportLibraryVersion" />
-	<set name="appcompatLibraryVersion" value="23.2.0" unless="appcompatLibraryVersion" />
+	<set name="playServicesVersion" value="+" unless="playServicesVersion" />
+	<set name="supportLibraryVersion" value="+" unless="supportLibraryVersion" />
+	<set name="appcompatLibraryVersion" value="+" unless="appcompatLibraryVersion" />
 </extension>


### PR DESCRIPTION
I think the extension should be set to use the latest version by default, as each dev. can set it's own version for each game anyway. 

PS: Version 9.4.0 had reported memory leaks that had been fixed.
